### PR TITLE
Fixed 'addto' and 'exportmodel' commands, fixed CollisionGeometryBuilder

### DIFF
--- a/HaloOnlineTagTool/Commands/Editing/AddToBlockCommand.cs
+++ b/HaloOnlineTagTool/Commands/Editing/AddToBlockCommand.cs
@@ -103,7 +103,10 @@ namespace HaloOnlineTagTool.Commands.Editing
             var blockValue = field.GetValue(Owner) as IList;
 
             if (blockValue == null)
-                field.SetValue(Owner, Activator.CreateInstance(field.FieldType));
+            {
+                blockValue = Activator.CreateInstance(field.FieldType) as IList;
+                field.SetValue(Owner, blockValue);
+            }
 
             var elementType = field.FieldType.GenericTypeArguments[0];
 

--- a/HaloOnlineTagTool/Commands/Editing/AddToBlockCommand.cs
+++ b/HaloOnlineTagTool/Commands/Editing/AddToBlockCommand.cs
@@ -146,8 +146,22 @@ namespace HaloOnlineTagTool.Commands.Editing
                     new TagStructureInfo(elementType));
 
                 while (enumerator.Next())
-                    if (enumerator.Field.GetValue(element) == null)
+                {
+                    var fieldType = enumerator.Field.FieldType;
+
+                    if (fieldType.IsArray && enumerator.Attribute.Count > 0)
+                    {
+                        var array = (IList)Activator.CreateInstance(enumerator.Field.FieldType,
+                            new object[] { enumerator.Attribute.Count });
+
+                        for (var i = 0; i < enumerator.Attribute.Count; i++)
+                            array[i] = CreateElement(fieldType.GetElementType());
+                    }
+                    else
+                    {
                         enumerator.Field.SetValue(element, CreateElement(enumerator.Field.FieldType));
+                    }
+                }
             }
 
             return element;

--- a/HaloOnlineTagTool/Commands/Editing/AddToBlockCommand.cs
+++ b/HaloOnlineTagTool/Commands/Editing/AddToBlockCommand.cs
@@ -105,8 +105,29 @@ namespace HaloOnlineTagTool.Commands.Editing
             if (fieldValue == null)
                 field.SetValue(Owner, Activator.CreateInstance(field.FieldType));
 
+            var genericType = field.FieldType.GenericTypeArguments[0];
+
             for (var i = 0; i < count; i++)
-                fieldValue.Add(Activator.CreateInstance(field.FieldType.GenericTypeArguments[0]));
+            {
+                var element = Activator.CreateInstance(genericType);
+
+                var isTagStructure = genericType.CustomAttributes.ToList()
+                    .Find(x => x.AttributeType == typeof(TagStructureAttribute)) != null;
+
+                if (isTagStructure)
+                {
+                    var e = new TagFieldEnumerator(
+                        new TagStructureInfo(genericType));
+                    while (e.Next())
+                    {
+                        if (e.Field.GetValue(element) == null)
+                            e.Field.SetValue(element,
+                                Activator.CreateInstance(e.Field.FieldType));
+                    }
+                }
+
+                fieldValue.Add(element);
+            }
 
             field.SetValue(Owner, fieldValue);
 

--- a/HaloOnlineTagTool/Commands/Models/ExtractModelCommand.cs
+++ b/HaloOnlineTagTool/Commands/Models/ExtractModelCommand.cs
@@ -111,7 +111,8 @@ namespace HaloOnlineTagTool.Commands.Models
                             if (region.Permutations.Count == 0)
                                 continue;
                             var permutation = region.Permutations[0];
-                            if (permutation.RenderModelPermutationIndex >= renderModelRegion.Permutations.Count)
+                            if (permutation.RenderModelPermutationIndex < 0 ||
+                                permutation.RenderModelPermutationIndex >= renderModelRegion.Permutations.Count)
                                 continue;
                             var renderModelPermutation = renderModelRegion.Permutations[permutation.RenderModelPermutationIndex];
 

--- a/HaloOnlineTagTool/Resources/Geometry/CollisionGeometryBuilder.cs
+++ b/HaloOnlineTagTool/Resources/Geometry/CollisionGeometryBuilder.cs
@@ -240,7 +240,7 @@ namespace HaloOnlineTagTool.Resources.Geometry
 
             reader.BaseStream.Position = originalPos + BSP_VERTICES_OFFSET;
             int n_vertices = BitConverter.ToInt32(reader.ReadBytes(4).Reverse().ToArray(), 0);
-            
+
             reader.BaseStream.Position = originalPos + BSP_SIZE;
             reader.BaseStream.Position = ParseBSP3DNodes(bsp, reader, n_3dnodes);
             reader.BaseStream.Position = ParsePlanes(bsp, reader, n_planes);
@@ -292,7 +292,7 @@ namespace HaloOnlineTagTool.Resources.Geometry
                 bsp3dNode.FrontChildLower = (byte)(front_child_trun & 0xff);
                 bsp3dNode.FrontChildMid = (byte)((front_child_trun >> 8) & 0xff);
                 bsp3dNode.FrontChildUpper = (byte)((front_child_trun >> 16) & 0xff);
-                
+
                 bsp.Bsp3dNodes.Add(bsp3dNode);
             }
 
@@ -335,13 +335,15 @@ namespace HaloOnlineTagTool.Resources.Geometry
                 reader.BaseStream.Position = originalPos + (i * LEAF_SIZE);
                 var flags = BitConverter.ToInt16(reader.ReadBytes(2).Reverse().ToArray(), 0);
                 var bsp2dRefCount = BitConverter.ToUInt16(reader.ReadBytes(2).Reverse().ToArray(), 0);
-                var first2dRef = BitConverter.ToInt32(reader.ReadBytes(4).Reverse().ToArray(), 0);
+                var Unknown = BitConverter.ToInt32(reader.ReadBytes(4).Reverse().ToArray(), 0);
+                var first2dRef = BitConverter.ToInt16(reader.ReadBytes(2).Reverse().ToArray(), 0);
 
                 var leaf = new BSP.Leaf();
 
                 leaf.Flags = flags;
                 leaf.Bsp2dReferenceCount = (short)bsp2dRefCount;
-                leaf.FirstBsp2dReference = (short)first2dRef;
+                leaf.Unknown = (short)Unknown;
+                leaf.FirstBsp2dReference = first2dRef;
 
                 bsp.Leaves.Add(leaf);
             }
@@ -380,7 +382,7 @@ namespace HaloOnlineTagTool.Resources.Geometry
 
             return originalPos + (count * BSP2DREFERENCE_SIZE);
         }
-        
+
         public long ParseBSP2DNodes(BSP bsp, BinaryReader reader, int count)
         {
             bsp.Bsp2dNodes = new List<BSP.Bsp2dNode>();
@@ -446,7 +448,7 @@ namespace HaloOnlineTagTool.Resources.Geometry
                 surface.Material = material;
                 surface.BreakableSurface = breakable_surface;
                 surface.Unknown2 = flags;
-                
+
                 bsp.Surfaces.Add(surface);
             }
             return originalPos + (count * SURFACE_SIZE);
@@ -590,7 +592,7 @@ namespace HaloOnlineTagTool.Resources.Geometry
 
             // h1 ce tags will have a 64 byte header. The main struct is immediately after.
 
-            var  len = reader.BaseStream.Length;
+            var len = reader.BaseStream.Length;
             reader.BaseStream.Position = MAIN_STRUCT_OFFSET;
             var size = ParseMain(coll, reader);
 


### PR DESCRIPTION
When adding a new tag block element with the 'addto' command, the new element's fields were not properly initialized, thus resulting in nulled fields instead of being zero or empty. Elements are now initialized recursively.

The hlmt 'exportmodel' command was not checking if a permutation's mesh index was set to -1, so a check was added to the predicate before attempting to extract the mesh.

@dany5639 pointed out that the CollisionGeometryBuilder was not working correctly for large objects and submitted a working fix for this.
