### PR TITLE
Added a default constructor to TagInstance.cs

### DIFF
--- a/HaloOnlineTagTool/TagInstance.cs
+++ b/HaloOnlineTagTool/TagInstance.cs
@@ -22,6 +22,12 @@ namespace HaloOnlineTagTool
         // Size of a tag header with no dependencies or offsets
         private const uint TagHeaderSize = 0x24;
 
+        public TagInstance()
+        {
+            // If no index is provided then create a null index
+            Index = -1;
+        }
+
         internal TagInstance(int index)
         {
             Index = index;


### PR DESCRIPTION
This prevents a crash when using the AddTo command on a tag that contains a pointer to another tag.

For example:
`tags.dat\0x028E.multiplayer_globals\universal[0]\spartanarmorcustomization[0]> addto permutations`

Would cause "ERROR: No parameterless constructor defined for this object."
