### PR TITLE
Locale changing

### DIFF
--- a/HaloOnlineTagTool/Commands/Core/SetLocaleCommand.cs
+++ b/HaloOnlineTagTool/Commands/Core/SetLocaleCommand.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace HaloOnlineTagTool.Commands.Core
+{
+    class SetLocaleCommand : Command
+    {
+        public SetLocaleCommand()
+            : base(CommandFlags.Inherit,
+                  "SetLocale",
+                  "Changes the parsing locale of numbers to the specified locale.",
+                  "SetLocale <locale>",
+        {
+        }
+
+        public override bool Execute(List<string> args)
+        {
+            if (args.Count < 1)
+                return false;
+            CultureInfo ci;
+            try
+            {
+                ci = CultureInfo.GetCultureInfo(args[0]);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return false;
+            }
+            CultureInfo.DefaultThreadCurrentCulture = ci;
+            return true;
+        }
+    }
+}

--- a/HaloOnlineTagTool/Commands/Core/SetLocaleCommand.cs
+++ b/HaloOnlineTagTool/Commands/Core/SetLocaleCommand.cs
@@ -11,6 +11,7 @@ namespace HaloOnlineTagTool.Commands.Core
                   "SetLocale",
                   "Changes the parsing locale of numbers to the specified locale.",
                   "SetLocale <locale>",
+                  "Use a culture name from https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo(vs.71).aspx")
         {
         }
 

--- a/HaloOnlineTagTool/Commands/Tags/TagCacheContextFactory.cs
+++ b/HaloOnlineTagTool/Commands/Tags/TagCacheContextFactory.cs
@@ -21,6 +21,7 @@ namespace HaloOnlineTagTool.Commands.Tags
             context.AddCommand(new DuplicateTagCommand(info));
             context.AddCommand(new AddressCommand());
             context.AddCommand(new ResourceDataCommand());
+            context.AddCommand(new SetLocaleCommand());
             if (info.StringIds != null)
             {
                 context.AddCommand(new EditCommand(stack, info));

--- a/HaloOnlineTagTool/HaloOnlineTagTool.csproj
+++ b/HaloOnlineTagTool/HaloOnlineTagTool.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Commands\Core\DumpLogCommand.cs" />
     <Compile Include="Commands\Core\EchoCommand.cs" />
     <Compile Include="Commands\Core\HelpCommand.cs" />
+    <Compile Include="Commands\Core\SetLocaleCommand.cs" />
     <Compile Include="Commands\Editing\AddToBlockCommand.cs" />
     <Compile Include="Commands\Editing\EditBlockCommand.cs" />
     <Compile Include="Commands\Editing\EditTagContextFactory.cs" />

--- a/HaloOnlineTagTool/Program.cs
+++ b/HaloOnlineTagTool/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using HaloOnlineTagTool.Commands;
 using HaloOnlineTagTool.Commands.Tags;
 using HaloOnlineTagTool.Serialization;
+using System.Globalization;
 
 namespace HaloOnlineTagTool
 {
@@ -14,6 +15,8 @@ namespace HaloOnlineTagTool
         static void Main(string[] args)
         {
             ConsoleHistory.Initialize();
+
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.GetCultureInfo("en-US");
 
             // Get the file path from the first argument
             // If no argument is given, load tags.dat


### PR DESCRIPTION
Addresses issue #22 

Using the command SetLocale <locale> the input and output of numbers is changed.

Useful for those that use comma separated decimals instead of period separated. The added benefit is that those same people can distribute their mods using their preferred decimal separated numbers as long as they specify the locale.
